### PR TITLE
Add option to enable 3D buildings

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -183,6 +183,12 @@
             "text": true
           },
           "suppressFormatPainterCopy": true
+        },
+        "extrudeBuildings": {
+          "displayName": "3D Buildings",
+          "displayNameKey": "extrudeBuildings",
+          "description": "Show 3D buildings",
+          "type": { "bool": true }
         }
       }
     },

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -2,14 +2,14 @@
   "visual": {
     "name": "mapboxGLMap",
     "displayName": "Mapbox Visual",
-    "guid": "PBI_CV_EB3A4088_75C5_4746_9D8B_255A7B7ECD6C_2",
+    "guid": "PBI_CV_EB3A4088_75C5_4746_9D8B_255A7B7ECD6C_3",
     "visualClassName": "MapboxMap",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Visualze massive location data with custom map styles, using circle, heatmap, and cluster layers.",
     "supportUrl": "www.mapbox.com/help",
     "gitHubUrl": "https://github.com/mapbox/mapboxgl-powerbi"
   },
-  "apiVersion": "1.10.0",
+  "apiVersion": "1.11.0",
   "author": {
     "name": "Mapbox",
     "email": "ryan.baumann@mapbox.com"

--- a/src/ts/settings.ts
+++ b/src/ts/settings.ts
@@ -33,6 +33,7 @@ module powerbi.extensibility.visual {
         public accessToken: string = "";
         public style: string = "mapbox:\/\/styles\/mapbox\/dark-v9?optimize=true";
         public styleUrl: string = "";
+        public extrudeBuildings: boolean = true;
 
         public enumerateObjectInstances(objectEnumeration) {
             let instances = objectEnumeration.instances;


### PR DESCRIPTION
Work in progress.  Removes the need for a user to go to Mapbox Studio to add 3D buildings to a Mapbox provided style.

Also upgrades to Power BI Visual tools v1.11

![](https://cl.ly/2v1w3P3X0D3O/download/Screen%20recording%202018-04-08%20at%2006.25.17%20PM.gif)