### PR TITLE
[POC] Add drilldown functionality for Location field

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -57,8 +57,21 @@
       "description": "Values to display in tooltips"
     }
   ],
+    "drilldown": {
+    "roles": ["location"]
+  },
   "dataViewMappings": [
     {
+      "conditions": [
+        {
+          "location": {
+            "max": 1
+          },
+          "color": {
+            "max": 1
+          }
+        }
+      ],
         "categorical": {
             "categories": {
                 "dataReductionAlgorithm": {


### PR DESCRIPTION
* POC branch for adding drill-down functionality to Choropleth layers for the `Location` field

### To Do:

- [ ] Add a second tileset for 2nd level of drilldown detail, and use that tileset for the Choropleth layer when clicking on the drill down button

![](https://cl.ly/242L3J2W0I1x/download/Screen%20recording%202018-05-14%20at%2008.27.05%20AM.gif)

