### PR TITLE
Configurable highlight

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -715,6 +715,18 @@
             }
           }
         },
+        "highlightColor": {
+          "displayName": "Highlight Color",
+          "displayNameKey": "highlightColor",
+          "description": "Defines the color a polyon will take when highlighted.",
+          "type": {
+            "fill": {
+              "solid": {
+                "color": true
+              }
+            }
+          }
+        },
         "minZoom": {
           "displayName": "Min Zoom",
           "displayNameKey": "minZoom",

--- a/capabilities.json
+++ b/capabilities.json
@@ -415,6 +415,18 @@
             }
           }
         },
+        "highlightColor": {
+          "displayName": "Highlight Color",
+          "displayNameKey": "highlightColor",
+          "description": "Defines the color a polyon will take when highlighted.",
+          "type": {
+            "fill": {
+              "solid": {
+                "color": true
+              }
+            }
+          }
+        },
         "minZoom": {
           "displayName": "Min Zoom",
           "displayNameKey": "minZoom",

--- a/src/ts/layers/choropleth.ts
+++ b/src/ts/layers/choropleth.ts
@@ -116,7 +116,6 @@ module powerbi.extensibility.visual {
             let locationFilter = [];
             locationFilter.push("any");
             let featureNameMap = {};
-            console.log('updating properties2')
             let selectionIds = features
                 .filter((feature) => {
                     // Dedupliacate features since features may appear multiple times in query results
@@ -203,7 +202,6 @@ module powerbi.extensibility.visual {
             super.applySettings(settings, roleMap);
             const map = this.parent.getMap();
             const choroSettings = settings.choropleth;
-            console.log("applying settings test")
 
             if (map.getLayer(Choropleth.ID)) {
                 map.setLayoutProperty(Choropleth.ID, 'visibility', choroSettings.display() ? 'visible' : 'none');

--- a/src/ts/layers/choropleth.ts
+++ b/src/ts/layers/choropleth.ts
@@ -53,7 +53,7 @@ module powerbi.extensibility.visual {
                 type: 'fill',
                 source: 'choropleth-source',
                 paint: {
-                    "fill-color": constants.HIGHLIGHT_COLOR,
+                    "fill-color": choroSettings.highlightColor,
                     "fill-opacity": 1
                 },
                 "source-layer": sourceLayer,
@@ -116,6 +116,7 @@ module powerbi.extensibility.visual {
             let locationFilter = [];
             locationFilter.push("any");
             let featureNameMap = {};
+            console.log('updating properties2')
             let selectionIds = features
                 .filter((feature) => {
                     // Dedupliacate features since features may appear multiple times in query results
@@ -202,6 +203,7 @@ module powerbi.extensibility.visual {
             super.applySettings(settings, roleMap);
             const map = this.parent.getMap();
             const choroSettings = settings.choropleth;
+            console.log("applying settings test")
 
             if (map.getLayer(Choropleth.ID)) {
                 map.setLayoutProperty(Choropleth.ID, 'visibility', choroSettings.display() ? 'visible' : 'none');
@@ -284,7 +286,7 @@ module powerbi.extensibility.visual {
                     opacity = 0.5 * opacity;
                 }
                 map.setPaintProperty(Choropleth.ID, 'fill-opacity', opacity);
-
+                map.setPaintProperty(Choropleth.HighlightID, "fill-color", choroSettings.highlightColor)
                 map.setPaintProperty(Choropleth.OutlineID, 'line-color', settings.choropleth.outlineColor);
                 map.setPaintProperty(Choropleth.OutlineID, 'line-width', settings.choropleth.outlineWidth);
                 map.setPaintProperty(Choropleth.OutlineID, 'line-opacity', settings.choropleth.outlineOpacity / 100);

--- a/src/ts/layers/circle.ts
+++ b/src/ts/layers/circle.ts
@@ -43,7 +43,7 @@ module powerbi.extensibility.visual {
             map.addLayer(highlightLayer, beforeLayerId);
             map.addLayer(circleLayer, Circle.HighlightID);
 
-            map.setPaintProperty(Circle.HighlightID, 'circle-color', constants.HIGHLIGHT_COLOR);
+            map.setPaintProperty(Circle.HighlightID, 'circle-color', settings.circle.highlightColor);
             map.setPaintProperty(Circle.HighlightID, 'circle-opacity', 1);
             map.setPaintProperty(Circle.HighlightID, 'circle-stroke-width', 1);
             map.setPaintProperty(Circle.HighlightID, 'circle-stroke-color', 'black');
@@ -123,6 +123,7 @@ module powerbi.extensibility.visual {
 
                 map.setPaintProperty(Circle.ID, 'circle-radius', sizes);
                 map.setPaintProperty(Circle.HighlightID, 'circle-radius', sizes);
+                map.setPaintProperty(Circle.HighlightID, 'circle-color', settings.circle.highlightColor);
                 map.setPaintProperty(Circle.ID, 'circle-color', colors);
                 map.setLayerZoomRange(Circle.ID, settings.circle.minZoom, settings.circle.maxZoom);
                 map.setPaintProperty(Circle.ID, 'circle-blur', settings.circle.blur / 100);

--- a/src/ts/settings.ts
+++ b/src/ts/settings.ts
@@ -63,6 +63,7 @@ module powerbi.extensibility.visual {
         public minColor: string = "#ffffcc";
         public medColor: string = "#41b6c4";
         public maxColor: string = "#253494";
+        public highlightColor: string = "#253494";
         public blur: number = 0.0;
         public opacity: number = 80;
         public strokeWidth: number = 1;

--- a/src/ts/settings.ts
+++ b/src/ts/settings.ts
@@ -117,6 +117,7 @@ module powerbi.extensibility.visual {
         public minColor: string = "#edf8b1";
         public medColor: string = "#7fcdbb";
         public maxColor: string = "#2c7fb8";
+        public highlightColor: string = "#2c7fb8";
         public minZoom: number = 0;
         public maxZoom: number = 22;
 


### PR DESCRIPTION
Added support for end-user to configure the color used for highlighting and selection for chloropleth and circle maps in Power BI GUI.