### PR TITLE
Configure Map URL to support Atlas Server

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -305,6 +305,14 @@
           "type": {
             "bool": true
           }
+        },
+        "apiUrl": {
+          "displayName": "Mapbox API URL",
+          "displayNameKey": "apiUrl",
+          "description": "Default URL for map api requests.  Set this to your Mapbox Atlas server hostname.",
+          "type": {
+            "text": true
+          }
         }
       }
     },

--- a/src/ts/mapboxMap.ts
+++ b/src/ts/mapboxMap.ts
@@ -4,7 +4,7 @@ module powerbi.extensibility.visual {
     declare var MapboxDraw : any;
 
     export class MapboxMap implements IVisual {
-        private map: any;
+        private map: mapboxgl.Map;
         private mapDiv: HTMLDivElement;
         private errorDiv: HTMLDivElement;
         private autoZoomControl: AutoZoomControl;

--- a/src/ts/mapboxMap.ts
+++ b/src/ts/mapboxMap.ts
@@ -4,7 +4,7 @@ module powerbi.extensibility.visual {
     declare var MapboxDraw : any;
 
     export class MapboxMap implements IVisual {
-        private map: mapboxgl.Map;
+        private map: any;
         private mapDiv: HTMLDivElement;
         private errorDiv: HTMLDivElement;
         private autoZoomControl: AutoZoomControl;
@@ -165,6 +165,7 @@ module powerbi.extensibility.visual {
             }))
             this.layers.push(new Circle(this, this.palette))
             this.layers.push(new Choropleth(this, this.palette));
+            mapboxgl.config.API_URL = this.settings.api.apiUrl;
 
             const mapOptions = {
                 container: this.mapDiv,

--- a/src/ts/settings.ts
+++ b/src/ts/settings.ts
@@ -36,9 +36,10 @@ module powerbi.extensibility.visual {
         public style: string = "mapbox:\/\/styles\/mapbox\/light-v9?optimize=true";
         public styleUrl: string = "";
         public zoom: number = 0;
-        public startLong:  number = 0;
+        public startLong: number = 0;
         public startLat: number = 0;
         public autozoom: boolean = true;
+        public apiUrl: string = "https://api.mapbox.com"
 
         public enumerateObjectInstances(objectEnumeration) {
             let instances = objectEnumeration.instances;

--- a/src/types/mapbox-gl/index.d.ts
+++ b/src/types/mapbox-gl/index.d.ts
@@ -9,6 +9,7 @@
 declare namespace mapboxgl {
     let accessToken: string;
     let version: string;
+    let config: any;
 
     export function supported(options?: { failIfMajorPerformanceCaveat?: boolean }): boolean;
 
@@ -26,20 +27,12 @@ declare namespace mapboxgl {
         constructor(options?: MapboxOptions);
 
         addControl(control: Control, position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'): this;
-        
+
         addControl(control: IControl, position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'): this;
 
         removeControl(control: Control): this;
-        
+
         removeControl(control: IControl): this;
-
-        addClass(klass: string, options?: mapboxgl.StyleOptions): this;
-
-        removeClass(klass: string, options?: mapboxgl.StyleOptions): this;
-
-        setClasses(klasses: string[], options?: mapboxgl.StyleOptions): this;
-
-        hasClass(klass: string): boolean;
 
         getClasses(): string[];
 
@@ -399,7 +392,7 @@ declare namespace mapboxgl {
      * Navigation
      */
     export class NavigationControl extends Control {
-        constructor();
+		constructor(options?: {showCompass?: boolean, showZoom?: boolean});
     }
 
     export class PositionOptions {
@@ -413,6 +406,7 @@ declare namespace mapboxgl {
      */
     export class GeolocateControl extends Control {
         constructor(options?: { positionOptions?: PositionOptions, fitBoundsOptions?: FitBoundsOptions, trackUserLocation?: boolean, showUserLocation?: boolean });
+        trigger(): boolean;
     }
 
     /**
@@ -873,6 +867,7 @@ declare namespace mapboxgl {
         speed?: number;
         screenSpeed?: number;
         easing?: Function;
+        maxDuration?: number;
     }
 
     export interface FitBoundsOptions extends mapboxgl.FlyToOptions {
@@ -1102,6 +1097,7 @@ declare namespace mapboxgl {
         'circle-color'?: string | StyleFunction | Expression;
         'circle-blur'?: number | StyleFunction | Expression;
         'circle-opacity'?: number | StyleFunction | Expression;
+        'circle-opacity-transition'?: Transition;
         'circle-translate'?: number[] | Expression;
         'circle-translate-anchor'?: 'map' | 'viewport';
         'circle-pitch-scale'?: 'map' | 'viewport';


### PR DESCRIPTION
* Adds `API Url` config option in settings for all `mapbox://` requests used in a map style.  Defaults to `https://api.mapbox.com`.
* Works with Atlas Server

Example of using Atlas with Power BI

![](https://cl.ly/3a1n3i0e1o1E/download/Screen%20Recording%202018-06-14%20at%2012.00%20PM.gif)

cc/ @samgehret 