### PR TITLE
[POC] Use setFeatureState for hover/highlight/select

### DIFF
--- a/src/ts/filter.ts
+++ b/src/ts/filter.ts
@@ -1,5 +1,5 @@
 module powerbi.extensibility.visual {
-    declare var turf : any;
+    declare var turf: any;
     export class Filter {
         private box: HTMLElement;
         private start: any;
@@ -33,7 +33,7 @@ module powerbi.extensibility.visual {
         }
 
         public removeHighlightAndSelection(layers) {
-            layers.map( layer => {
+            layers.map(layer => {
                 layer.removeHighlight(this.mapVisual.getRoleMap());
             });
             this.mapVisual.clearSelection();
@@ -43,32 +43,34 @@ module powerbi.extensibility.visual {
 
             const map = this.mapVisual.getMap();
             map.boxZoom.disable();
+            const hoverHighLightLayers = [Circle.ID, Choropleth.ID];
 
             const clickHandler = this.createClickHandler(this.mapVisual)
             map.off('click', clickHandler);
             map.on('click', clickHandler);
 
             const mouseMoveHandler = mapboxUtils.debounce((e) => {
-                if (!this.mapVisual.hasSelection() && !this.selectionInProgress) {
-                    const layers = this.mapVisual.getExistingLayers();
-                    layers.map(layer => layer.hoverHighLight(e));
+
+                let features = map.queryRenderedFeatures(e.point, {
+                    layers: [Circle.ID]
+                });
+
+                if (features.length) {
+                    if (!this.mapVisual.hasSelection() && !this.selectionInProgress) {
+                        const layers = this.mapVisual.getExistingLayers();
+                        layers.map(layer => layer.hoverHighLight(features));
+                    }
+                } else {
+                    if (!this.mapVisual.hasSelection() && !this.selectionInProgress) {
+                        const layers = this.mapVisual.getExistingLayers();
+                        layers.map(layer => layer.removeHighlight(this.mapVisual.getRoleMap()));
+                    }
                 }
+
             }, 12, true);
 
-            const mouseLeaveHandler = mapboxUtils.debounce((e) => {
-                if (!this.mapVisual.hasSelection() && !this.selectionInProgress) {
-                    const layers = this.mapVisual.getExistingLayers();
-                    layers.map(layer => layer.removeHighlight(this.mapVisual.getRoleMap()));
-                }
-            }, 12, true);
-
-            const hoverHighLightLayers = [Circle.ID, Choropleth.ID];
-            hoverHighLightLayers.map(hhLayer => {
-                map.off('mousemove', hhLayer, mouseMoveHandler);
-                map.on('mousemove', hhLayer, mouseMoveHandler);
-                map.off('mouseleave', hhLayer, mouseLeaveHandler);
-                map.on('mouseleave', hhLayer, mouseLeaveHandler);
-            });
+            map.off('mousemove', mouseMoveHandler);
+            map.on('mousemove', mouseMoveHandler);
 
             const dragStartHandler = (e) => {
                 this.dragScreenX = e.originalEvent.screenX;
@@ -101,8 +103,8 @@ module powerbi.extensibility.visual {
                     this.dragScreenX + radius < e.originalEvent.screenX ||
                     this.dragScreenY - radius > e.originalEvent.screenY ||
                     this.dragScreenY + radius < e.originalEvent.screenY) {
-                        // It was a real drag event
-                        return;
+                    // It was a real drag event
+                    return;
                 }
 
                 // This drag event is considered to be click, so remove the highlight and selection
@@ -119,9 +121,9 @@ module powerbi.extensibility.visual {
             let canvas = map.getCanvasContainer();
             let rect = canvas.getBoundingClientRect();
             return new mapboxgl.Point(
-                    e.clientX - rect.left - canvas.clientLeft,
-                    e.clientY - rect.top - canvas.clientTop
-                );
+                e.clientX - rect.left - canvas.clientLeft,
+                e.clientY - rect.top - canvas.clientTop
+            );
         }
 
         onMouseDown(e) {
@@ -205,8 +207,8 @@ module powerbi.extensibility.visual {
                 const layers = this.mapVisual.getExistingLayers();
                 if (layers && layers.length > 0) {
                     const roleMap = this.mapVisual.getRoleMap();
-                    layers.map( layer => {
-                        let features = map.queryRenderedFeatures(bbox, { layers: [ layer.getId() ] });
+                    layers.map(layer => {
+                        let features = map.queryRenderedFeatures(bbox, { layers: [layer.getId()] });
                         layer.updateSelection(
                             features,
                             roleMap);
@@ -220,7 +222,7 @@ module powerbi.extensibility.visual {
         }
 
         createClickHandler(mapVisual: MapboxMap) {
-            let onClick : Function = (e) => {
+            let onClick: Function = (e) => {
                 const originalEvent = e.originalEvent;
                 if (originalEvent.shiftKey && originalEvent.button === 0 || this.selectionInProgress) {
                     // Selection is considered to be still in progress
@@ -251,8 +253,8 @@ module powerbi.extensibility.visual {
                 // map.queryRenderedFeatures fails
                 // when option.layers contains an id which is not on the map
                 layers.map(layer => {
-                    let features : any = map.queryRenderedFeatures([minpoint, maxpoint], {
-                        "layers": [ layer.getId() ]
+                    let features: any = map.queryRenderedFeatures([minpoint, maxpoint], {
+                        "layers": [layer.getId()]
                     });
 
                     if (features
@@ -283,8 +285,8 @@ module powerbi.extensibility.visual {
                 const bbox = turf.bbox(feature)
 
                 const pointCollection = turf.helpers.featureCollection([
-                    turf.helpers.point( [bbox[0], bbox[1]]),
-                    turf.helpers.point( [bbox[2], bbox[3]]),
+                    turf.helpers.point([bbox[0], bbox[1]]),
+                    turf.helpers.point([bbox[2], bbox[3]]),
                 ]);
 
                 const center = turf.center(pointCollection);

--- a/src/ts/mapboxMap.ts
+++ b/src/ts/mapboxMap.ts
@@ -132,8 +132,6 @@ module powerbi.extensibility.visual {
                     return cat.source.displayName == role.displayName;
                 })[0]
 
-                console.log(category);
-
                 indexes = values.map( value => category.values.indexOf(value));
             }
 

--- a/src/types/mapbox-gl/index.d.ts
+++ b/src/types/mapbox-gl/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mapbox GL JS v0.44.1
+// Type definitions for Mapbox GL JS v0.45.0
 // Project: https://github.com/mapbox/mapbox-gl-js
 // Definitions by: Dominik Bruderer <https://github.com/dobrud>, Patrick Reames <https://github.com/patrickr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -18,6 +18,7 @@ declare namespace mapboxgl {
     type LngLatBoundsLike = number[][] | LngLatLike[] | LngLatBounds;
     type PointLike = number[] | Point;
     type Expression = any[];
+    type Anchor = 'center' | 'left' | 'right' | 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
     /**
      * Map
@@ -26,22 +27,12 @@ declare namespace mapboxgl {
         constructor(options?: MapboxOptions);
 
         addControl(control: Control, position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'): this;
-        
+
         addControl(control: IControl, position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'): this;
 
         removeControl(control: Control): this;
-        
+
         removeControl(control: IControl): this;
-
-        addClass(klass: string, options?: mapboxgl.StyleOptions): this;
-
-        removeClass(klass: string, options?: mapboxgl.StyleOptions): this;
-
-        setClasses(klasses: string[], options?: mapboxgl.StyleOptions): this;
-
-        hasClass(klass: string): boolean;
-
-        getClasses(): string[];
 
         resize(): this;
 
@@ -61,9 +52,17 @@ declare namespace mapboxgl {
 
         unproject(point: PointLike): mapboxgl.LngLat;
 
+        isMoving(): boolean;
+
+        isZooming(): boolean;
+
+        isRotating(): boolean;
+
         queryRenderedFeatures(pointOrBox?: PointLike | PointLike[], parameters?: { layers?: string[], filter?: any[] }): GeoJSON.Feature<GeoJSONGeometry>[];
 
         querySourceFeatures(sourceID: string, parameters?: { sourceLayer?: string, filter?: any[] }): GeoJSON.Feature<GeoJSONGeometry>[];
+
+        setFeatureState({source: string, id: number}, value: any): this;
 
         setStyle(style: mapboxgl.Style | string): this;
 
@@ -207,9 +206,6 @@ declare namespace mapboxgl {
         /** initial map center */
         center?: LngLatLike;
 
-        /** Style class names with which to initialize the map */
-        classes?: string[];
-
         /** ID of the container element */
         container?: string | Element;
 
@@ -226,7 +222,7 @@ declare namespace mapboxgl {
         hash?: boolean;
 
         /** If true, map creation will fail if the implementation determines that the performance of the created WebGL context would be dramatically lower than expected. */
-        failIfMayorPerformanceCaveat?: boolean;
+        failIfMajorPerformanceCaveat?: boolean;
 
         /** If false, no mouse, touch, or keyboard listeners are attached to the map, so it will not respond to input */
         interactive?: boolean;
@@ -399,7 +395,7 @@ declare namespace mapboxgl {
      * Navigation
      */
     export class NavigationControl extends Control {
-        constructor();
+		constructor(options?: {showCompass?: boolean, showZoom?: boolean});
     }
 
     export class PositionOptions {
@@ -413,6 +409,7 @@ declare namespace mapboxgl {
      */
     export class GeolocateControl extends Control {
         constructor(options?: { positionOptions?: PositionOptions, fitBoundsOptions?: FitBoundsOptions, trackUserLocation?: boolean, showUserLocation?: boolean });
+        trigger(): boolean;
     }
 
     /**
@@ -427,6 +424,8 @@ declare namespace mapboxgl {
      */
     export class ScaleControl extends Control {
         constructor(options?: { maxWidth?: number, unit?: string })
+
+        setUnit(unit: 'imperial' | 'metric' | 'nautical'): void;
     }
 
     /**
@@ -464,7 +463,7 @@ declare namespace mapboxgl {
 
         closeOnClick?: boolean;
 
-        anchor?: 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+        anchor?: Anchor;
 
         offset?: number | PointLike | { [key: string]: PointLike; };
     }
@@ -493,8 +492,11 @@ declare namespace mapboxgl {
     export interface Light {
         'anchor'?: 'map' | 'viewport';
         'position'?: number[];
+        'position-transition'?: Transition;
         'color'?: string;
+        'color-transition'?: Transition;
         'intensity'?: number;
+        'intensity-transition'?: Transition;
     }
 
     export interface Source {
@@ -533,6 +535,8 @@ declare namespace mapboxgl {
         clusterRadius?: number;
 
         clusterMaxZoom?: number;
+
+        lineMetrics?: boolean;
     }
 
     /**
@@ -585,7 +589,7 @@ declare namespace mapboxgl {
 
         coordinates: number[][];
 
-        canvas: string;
+        canvas: string | HTMLCanvasElement;
 
         getCanvas(): HTMLCanvasElement;
 
@@ -597,7 +601,7 @@ declare namespace mapboxgl {
 
         animate?: boolean;
 
-        canvas: string;
+        canvas: string | HTMLCanvasElement;
     }
 
     interface VectorSource extends Source {
@@ -745,8 +749,13 @@ declare namespace mapboxgl {
         static convert(a: PointLike): Point;
     }
 
+    /**
+     * Marker
+     */
     export class Marker {
-        constructor(element?: HTMLElement, options?: { offset?: PointLike });
+        constructor(options?: mapboxgl.MarkerOptions);
+
+        constructor(element?: HTMLElement, options?: mapboxgl.MarkerOptions);
 
         addTo(map: Map): this;
 
@@ -767,6 +776,16 @@ declare namespace mapboxgl {
         togglePopup(): this;
     }
 
+    export interface MarkerOptions {
+        element?: HTMLElement;
+
+        offset?: PointLike;
+
+        anchor?: Anchor;
+
+        color?: string
+    }
+
     /**
      * Evented
      */
@@ -780,10 +799,6 @@ declare namespace mapboxgl {
         off(type?: string | any, layer?: string, listener?: Function): this;
 
         once(type: string, listener: Function): this;
-
-        fire(type: string, data?: mapboxgl.EventData | Object): this;
-
-        listens(type: string): boolean;
     }
 
     /**
@@ -810,16 +825,20 @@ declare namespace mapboxgl {
         originalEvent: MouseEvent;
         point: mapboxgl.Point;
         lngLat: mapboxgl.LngLat;
+        preventDefault(): void;
+        defaultPrevented: boolean;
     }
 
     export class MapTouchEvent {
         type: string;
-        target: Map;
+        map: Map;
         originalEvent: TouchEvent;
         point: mapboxgl.Point;
         lngLat: mapboxgl.LngLat;
         points: Point[];
         lngLats: LngLat[];
+        preventDefault(): void;
+        defaultPrevented: boolean;
     }
 
     export class MapBoxZoomEvent {
@@ -832,7 +851,17 @@ declare namespace mapboxgl {
         dataType: 'source' | 'style' | 'tile';
         isSourceLoaded?: boolean;
         source?: mapboxgl.Source;
+        sourceDataType?: string;
+        tile?: any;
         coord?: any;
+    }
+
+    export class MapWheelEvent {
+        type: string;
+        map: Map;
+        originalEvent: MouseEvent;
+        preventDefault(): void;
+        defaultPrevented: boolean;
     }
 
     /**
@@ -873,6 +902,7 @@ declare namespace mapboxgl {
         speed?: number;
         screenSpeed?: number;
         easing?: Function;
+        maxDuration?: number;
     }
 
     export interface FitBoundsOptions extends mapboxgl.FlyToOptions {
@@ -927,11 +957,12 @@ declare namespace mapboxgl {
         drag?: { data: mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent };
         dragend?: { data: mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent };
         pitch?: { data: mapboxgl.EventData };
+        wheel?: { data: mapboxgl.MapWheelEvent };
     }
 
     export interface Layer {
         id: string;
-        type?: 'fill' | 'line' | 'symbol' | 'circle' | 'fill-extrusion' | 'raster' | 'background' | 'heatmap';
+        type?: 'fill' | 'line' | 'symbol' | 'circle' | 'fill-extrusion' | 'raster' | 'background' | 'heatmap' | 'hillshade';
 
         metadata?: any;
         ref?: string;
@@ -946,8 +977,8 @@ declare namespace mapboxgl {
         interactive?: boolean;
 
         filter?: any[];
-        layout?: BackgroundLayout | FillLayout | FillExtrusionLayout | LineLayout | SymbolLayout | RasterLayout | CircleLayout | HeatmapLayout;
-        paint?: BackgroundPaint | FillPaint | FillExtrusionPaint | LinePaint | SymbolPaint | RasterPaint | CirclePaint | HeatmapPaint;
+        layout?: BackgroundLayout | FillLayout | FillExtrusionLayout | LineLayout | SymbolLayout | RasterLayout | CircleLayout | HeatmapLayout | HillshadeLayout;
+        paint?: BackgroundPaint | FillPaint | FillExtrusionPaint | LinePaint | SymbolPaint | RasterPaint | CirclePaint | HeatmapPaint | HillshadePaint;
     }
 
     export interface StyleFunction {
@@ -965,8 +996,11 @@ declare namespace mapboxgl {
 
     export interface BackgroundPaint {
         'background-color'?: string | Expression;
+        'background-color-transition'?: Transition;
         'background-pattern'?: string;
+        'background-pattern-transition'?: Transition;
         'background-opacity'?: number | Expression;
+        'background-opacity-transition'?: Transition;
     }
 
     export interface FillLayout {
@@ -976,11 +1010,16 @@ declare namespace mapboxgl {
     export interface FillPaint {
         'fill-antialias'?: boolean;
         'fill-opacity'?: number | StyleFunction | Expression;
+        'fill-opacity-transition'?: Transition;
         'fill-color'?: string | StyleFunction | Expression;
+        'fill-color-transition'?: Transition;
         'fill-outline-color'?: string | StyleFunction | Expression;
+        'fill-outline-color-transition'?: Transition;
         'fill-translate'?: number[] | Expression;
+        'fill-translate-transition'?: Transition;
         'fill-translate-anchor'?: 'map' | 'viewport';
         'fill-pattern'?: string;
+        'fill-pattern-transition'?: Transition;
     }
 
     export interface FillExtrusionLayout {
@@ -989,12 +1028,18 @@ declare namespace mapboxgl {
 
     export interface FillExtrusionPaint {
         'fill-extrusion-opacity'?: number | Expression;
+        'fill-extrusion-opacity-transition'?: Transition;
         'fill-extrusion-color'?: string | StyleFunction | Expression;
+        'fill-extrusion-color-transition'?: Transition;
         'fill-extrusion-translate'?: number[] | Expression;
+        'fill-extrusion-translate-transition'?: Transition;
         'fill-extrusion-translate-anchor'?: 'map' | 'viewport';
         'fill-extrusion-pattern'?: string;
+        'fill-extrusion-pattern-transition'?: Transition;
         'fill-extrusion-height'?: number | StyleFunction | Expression;
+        'fill-extrusion-height-transition'?: Transition;
         'fill-extrusion-base'?: number | StyleFunction | Expression;
+        'fill-extrusion-base-transition'?: Transition;
     }
 
     export interface LineLayout {
@@ -1008,16 +1053,25 @@ declare namespace mapboxgl {
 
     export interface LinePaint {
         'line-opacity'?: number | StyleFunction | Expression;
+        'line-opacity-transition'?: Transition;
         'line-color'?: string | StyleFunction | Expression;
+        'line-color-transition'?: Transition;
         'line-translate'?: number[] | Expression;
+        'line-translate-transition'?: Transition;
         'line-translate-anchor'?: 'map' | 'viewport';
         'line-width'?: number | StyleFunction | Expression;
+        'line-width-transition'?: Transition;
         'line-gap-width'?: number | StyleFunction | Expression;
+        'line-gap-width-transition'?: Transition;
         'line-offset'?: number | StyleFunction | Expression;
+        'line-offset-transition'?: Transition;
         'line-blur'?: number | StyleFunction | Expression;
+        'line-blur-transition'?: Transition;
         'line-dasharray'?: number[];
         'line-dasharray-transition'?: Transition;
         'line-pattern'?: string;
+        'line-pattern-transition'?: Transition;
+        'line-gradient'?: Expression;
     }
 
     export interface SymbolLayout {
@@ -1026,11 +1080,10 @@ declare namespace mapboxgl {
         'symbol-placement'?: 'point' | 'line';
         'symbol-spacing'?: number | Expression;
         'symbol-avoid-edges'?: boolean;
-        'icon-allow-overlap'?: boolean;
+        'icon-allow-overlap'?: boolean | StyleFunction;
         'icon-ignore-placement'?: boolean;
         'icon-optional'?: boolean;
         'icon-rotation-alignment'?: 'map' | 'viewport' | 'auto';
-        'icon-pitch-alignment'?: 'map' | 'viewport' | 'auto';
         'icon-size'?: number | StyleFunction | Expression;
         'icon-text-fit'?: 'none' | 'both' | 'width' | 'height';
         'icon-text-fit-padding'?: number[] | Expression;
@@ -1039,6 +1092,8 @@ declare namespace mapboxgl {
         'icon-padding'?: number | Expression;
         'icon-keep-upright'?: boolean;
         'icon-offset'?: number[] | StyleFunction | Expression;
+        'icon-anchor'?: Anchor;
+        'icon-pitch-alignment'?: 'map' | 'viewport' | 'auto';
         'text-pitch-alignment'?: 'map' | 'viewport' | 'auto';
         'text-rotation-alignment'?: 'map' | 'viewport' | 'auto';
         'text-field'?: string | StyleFunction;
@@ -1048,7 +1103,7 @@ declare namespace mapboxgl {
         'text-line-height'?: number | Expression;
         'text-letter-spacing'?: number | Expression;
         'text-justify'?: 'left' | 'center' | 'right';
-        'text-anchor'?: 'center' | 'left' | 'right' | 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+        'text-anchor'?: Anchor;
         'text-max-angle'?: number | Expression;
         'text-rotate'?: number | StyleFunction | Expression;
         'text-padding'?: number | Expression;
@@ -1058,23 +1113,34 @@ declare namespace mapboxgl {
         'text-allow-overlap'?: boolean;
         'text-ignore-placement'?: boolean;
         'text-optional'?: boolean;
-
     }
 
     export interface SymbolPaint {
         'icon-opacity'?: number | StyleFunction | Expression;
+        'icon-opacity-transition'?: Transition;
         'icon-color'?: string | StyleFunction | Expression;
+        'icon-color-transition'?: Transition;
         'icon-halo-color'?: string | StyleFunction | Expression;
+        'icon-halo-color-transition'?: Transition;
         'icon-halo-width'?: number | StyleFunction | Expression;
+        'icon-halo-width-transition'?: Transition;
         'icon-halo-blur'?: number | StyleFunction | Expression;
+        'icon-halo-blur-transition'?: Transition;
         'icon-translate'?: number[] | Expression;
+        'icon-translate-transition'?: Transition;
         'icon-translate-anchor'?: 'map' | 'viewport';
         'text-opacity'?: number | StyleFunction | Expression;
+        'text-opacity-transition'?: Transition;
         'text-color'?: string | StyleFunction | Expression;
+        'text-color-transition'?: Transition;
         'text-halo-color'?: string | StyleFunction | Expression;
+        'text-halo-color-transition'?: Transition;
         'text-halo-width'?: number | StyleFunction | Expression;
+        'text-halo-width-transition'?: Transition;
         'text-halo-blur'?: number | StyleFunction | Expression;
+        'text-halo-blur-transition'?: Transition;
         'text-translate'?: number[] | Expression;
+        'text-translate-transition'?: Transition;
         'text-translate-anchor'?: 'map' | 'viewport';
     }
 
@@ -1084,11 +1150,17 @@ declare namespace mapboxgl {
 
     export interface RasterPaint {
         'raster-opacity'?: number | Expression;
+        'raster-opacity-transition'?: Transition;
         'raster-hue-rotate'?: number | Expression;
+        'raster-hue-rotate-transition'?: Transition;
         'raster-brightness-min'?: number | Expression;
+        'raster-brightness-min-transition'?: Transition;
         'raster-brightness-max'?: number | Expression;
+        'raster-brightness-max-transition'?: Transition;
         'raster-saturation'?: number | Expression;
+        'raster-saturation-transition'?: Transition;
         'raster-contrast'?: number | Expression;
+        'raster-contrast-transition'?: Transition;
         'raster-fade-duration'?: number | Expression;
     }
 
@@ -1100,15 +1172,22 @@ declare namespace mapboxgl {
         'circle-radius'?: number | StyleFunction | Expression;
         'circle-radius-transition'?: Transition;
         'circle-color'?: string | StyleFunction | Expression;
+        'circle-color-transition'?: Transition;
         'circle-blur'?: number | StyleFunction | Expression;
+        'circle-blur-transition'?: Transition;
         'circle-opacity'?: number | StyleFunction | Expression;
+        'circle-opacity-transition'?: Transition;
         'circle-translate'?: number[] | Expression;
+        'circle-translate-transition'?: Transition;
         'circle-translate-anchor'?: 'map' | 'viewport';
         'circle-pitch-scale'?: 'map' | 'viewport';
         'circle-pitch-alignment'?: 'map' | 'viewport';
         'circle-stroke-width'?: number | StyleFunction | Expression;
+        'circle-stroke-width-transition'?: Transition;
         'circle-stroke-color'?: string | StyleFunction | Expression;
+        'circle-stroke-color-transition'?: Transition;
         'circle-stroke-opacity'?: number | StyleFunction | Expression;
+        'circle-stroke-opacity-transition'?: Transition;
     }
 
     export interface HeatmapLayout {
@@ -1117,13 +1196,30 @@ declare namespace mapboxgl {
 
     export interface HeatmapPaint {
         'heatmap-radius'?: number | Expression;
-        'heatmap-transition'?: Transition;
+        'heatmap-radius-transition'?: Transition;
         'heatmap-weight'?: number | StyleFunction | Expression;
         'heatmap-intensity'?: number | Expression;
+        'heatmap-intensity-transition'?: Transition;
         'heatmap-color'?: string | Expression;
-        'heatmap-color-transition'?: Transition;
         'heatmap-opacity'?: number | Expression;
         'heatmap-opacity-transition'?: Transition;
+    }
+
+    export interface HillshadeLayout {
+        visibility?: 'visible' | 'none';
+    }
+
+    export interface HillshadePaint {
+        'hillshade-illumination-direction'?: number | Expression;
+        'hillshade-illumination-anchor'?: 'map' | 'viewport';
+        'hillshade-exaggeration'?: number | Expression;
+        'hillshade-exaggeration-transition'?: Transition;
+        'hillshade-shadow-color'?: string | Expression;
+        'hillshade-shadow-color-transition'?: Transition;
+        'hillshade-highlight-color'?: string | Expression;
+        'hillshade-highlight-color-transition'?: Transition;
+        'hillshade-accent-color'?: string | Expression;
+        'hillshade-accent-color-transition'?: Transition;
     }
 }
 


### PR DESCRIPTION
# Problem

Layer filters are slow, and can hinder interactivity on the main thread of the map, especially when moving the mouse quickly over many data points.  

# Solution 

In Mapbox GL JS v0.46.0, feature states were introduced.  This allows managing the state of each feature individually within a layer using expressions, instead of requiring a separate side-along hover/highlight/select layer with a filter.  

# Scope

This POC branch implements featureStates for the `circle` layer.  It replaces the use of the hover/highlight layer for circles.  The benefit is that this change improves the performance of the map when hovering and selecting, especially on browsers other than chrome.

This POC does not improve the performance of the createSelectionIdBuilder() function that Power BI Visuals Tools runs to send the selected items to other dashboard elements.  That is still the major bottleneck when selecting more than a few hundred features.

# Example

## With new FeatureStates

![](https://cl.ly/3i3L3d1q0k1W/download/Screen%20recording%202018-06-17%20at%2010.35.24%20AM.gif)

## With old layer filters

![ezgif com-optimize 1](https://user-images.githubusercontent.com/4342845/41510523-14aedb1c-721b-11e8-8c06-69ad8d2985fd.gif)


# To Do

- [ ] Fix bug where mousemove handlers are attached to map before circle layer exists in map
- [ ] Improve selected layer style to be more like the current layer filter style
- [ ] Apply changes to choropleth layer to mirror the circle layer

cc/ @samgehret